### PR TITLE
[TECHNICAL SUPPORT] LPS-68593 part of alloy-editor

### DIFF
--- a/src/plugins/placeholder.js
+++ b/src/plugins/placeholder.js
@@ -46,16 +46,14 @@
             _checkEmptyData: function(event) {
                 var editor = event.editor;
 
-                if (editor.getData() === '') {
-                    var editorNode = new CKEDITOR.dom.element(editor.element.$);
+                var editorNode = new CKEDITOR.dom.element(editor.element.$);
 
-                    // Despite getData() returns empty string, the content still may have
-                    // data - an empty paragraph. This breaks the :empty selector in
-                    // placeholder's CSS and placeholder does not appear.
-                    // For that reason, we will intentionally remove any content from editorNode.
-                    editorNode.setHtml('');
+                if (editor.getData() === '') {
 
                     editorNode.addClass(editor.config.placeholderClass);
+                }
+                else {
+                    editorNode.removeClass(editor.config.placeholderClass);
                 }
             }
         }

--- a/src/ui/react/demo/index.html
+++ b/src/ui/react/demo/index.html
@@ -82,9 +82,21 @@
         </div>
 
         <script>
-            var editor1 = AlloyEditor.editable('description');
-            var editor2 = AlloyEditor.editable('editable');
-            var editor3 = AlloyEditor.editable('headline');
+            var editor1 = AlloyEditor.editable('headline');
+            var editor2 = AlloyEditor.editable('description', {
+                buttonCfg: {
+                    'linkEdit': {
+                        showTargetSelector: true
+                    }
+                }
+            });
+            var editor3 = AlloyEditor.editable('editable', {
+                buttonCfg: {
+                    'linkEdit': {
+                        showTargetSelector: false
+                    }
+                }
+            });
         </script>
 
         <div id="footer">

--- a/src/ui/react/src/assets/sass/components/ae-placeholder/structure.scss
+++ b/src/ui/react/src/assets/sass/components/ae-placeholder/structure.scss
@@ -1,3 +1,3 @@
-.ae-placeholder:empty:not(:focus):before {
+.ae-placeholder:not(:focus):before {
     content: attr(data-placeholder);
 }

--- a/src/ui/react/src/components/buttons/button-link-edit.jsx
+++ b/src/ui/react/src/components/buttons/button-link-edit.jsx
@@ -200,13 +200,19 @@
                 autocompleteDropdown = <AlloyEditor.ButtonLinkAutocompleteList {...autocompleteDropdownProps} />;
             }
 
+            var targetButtonEdit;
+
+            if (this.props.showTargetSelector) {
+                targetButtonEdit = <AlloyEditor.ButtonLinkTargetEdit {...targetSelector} />;
+            }
+
             return (
                 <div className="ae-container-edit-link">
                     <button aria-label={AlloyEditor.Strings.removeLink} className="ae-button" disabled={!this.state.element} onClick={this._removeLink} title={AlloyEditor.Strings.remove}>
                         <span className="ae-icon-unlink"></span>
                     </button>
                     <div className="ae-container-input xxl">
-                        <AlloyEditor.ButtonLinkTargetEdit {...targetSelector} />
+                       {targetButtonEdit}
                         <div className="ae-container-input flexible">
                             <input className="ae-input" onChange={this._handleLinkHrefChange} onKeyDown={this._handleKeyDown} placeholder={AlloyEditor.Strings.editLink} ref="linkInput" type="text" value={this.state.linkHref}></input>
                             {autocompleteDropdown}

--- a/src/ui/react/test/button-link-edit.jsx
+++ b/src/ui/react/test/button-link-edit.jsx
@@ -66,7 +66,7 @@
             assert.strictEqual('<p><a href="link.com" target="">selection</a></p>', data);
         });
 
-        it.only('should propagate `allowedTargets` property to `ButtonLinkTargetEdit`', function() {
+        it('should propagate `allowedTargets` property to `ButtonLinkTargetEdit`', function() {
             var allowedTargets = [
                 {
                     label: AlloyEditor.Strings.linkTargetDefault,

--- a/test/plugins/test/placeholder.js
+++ b/test/plugins/test/placeholder.js
@@ -1,0 +1,41 @@
+(function() {
+	'use strict';
+
+	var assert = chai.assert;
+
+	describe('Placeholder', function() {
+		this.timeout(35000);
+
+		before(function(done) {
+            Utils.createCKEditor.call(this, done, {extraPlugins: 'ae_placeholder', placeholderClass: 'ae-placeholder'}, {'data-placeholder': 'This is placeholder'});
+        });
+
+        after(Utils.destroyCKEditor);
+
+        beforeEach(Utils.beforeEach);
+
+        afterEach(Utils.afterEach);
+
+        it('should html value of content editor is the value when instance is created', function() {
+            assert.strictEqual(this.nativeEditor.editable().getHtml(), '<p><br></p>');
+            assert.isTrue(this.nativeEditor.element.hasClass('ae-placeholder'));
+        });
+
+        it('should html value of content editor is not changed after it is blur when its value is empty', function() {
+            this.nativeEditor.fire('blur');
+
+            assert.strictEqual(this.nativeEditor.editable().getHtml(), '<p><br></p>');
+            assert.isTrue(this.nativeEditor.element.hasClass('ae-placeholder'));
+
+        });
+
+        it('should keep value when input is blur and input has content', function() {
+            bender.tools.selection.setWithHtml(this.nativeEditor, 'This input has content');
+
+            this.nativeEditor.fire('blur');
+            assert.strictEqual(this.nativeEditor.editable().getHtml(), 'This input has content');
+            assert.isTrue(!this.nativeEditor.element.hasClass('ae-placeholder'));
+        });
+	});
+
+}());

--- a/test/plugins/test/placeholder.js
+++ b/test/plugins/test/placeholder.js
@@ -16,12 +16,12 @@
 
         afterEach(Utils.afterEach);
 
-        it('should html value of content editor is the value when instance is created', function() {
+        it('should assert the html value of the editor is the same as passed value on creating the instance', function() {
             assert.strictEqual(this.nativeEditor.editable().getHtml(), '<p><br></p>');
             assert.isTrue(this.nativeEditor.element.hasClass('ae-placeholder'));
         });
 
-        it('should html value of content editor is not changed after it is blur when its value is empty', function() {
+        it('should not change the html value after the editor is blurred when its value is empty', function() {
             this.nativeEditor.fire('blur');
 
             assert.strictEqual(this.nativeEditor.editable().getHtml(), '<p><br></p>');
@@ -29,7 +29,7 @@
 
         });
 
-        it('should keep value when input is blur and input has content', function() {
+        it('should keep the value when input is blurred and input has content', function() {
             bender.tools.selection.setWithHtml(this.nativeEditor, 'This input has content');
 
             this.nativeEditor.fire('blur');

--- a/test/util/utils.js
+++ b/test/util/utils.js
@@ -44,11 +44,17 @@
             }
         },
 
-        createCKEditor: function(done, config) {
+        createCKEditor: function(done, config, attributes) {
             var editable = document.createElement('div');
 
             editable.setAttribute('id', 'editable');
             editable.setAttribute('contenteditable', true);
+
+            if (attributes) {
+                for (var attribute in attributes) {
+                    editable.setAttribute(attribute, attributes[attribute]);
+                }
+            }
 
             document.getElementsByTagName('body')[0].appendChild(editable);
 

--- a/test/util/utils.js
+++ b/test/util/utils.js
@@ -1,4 +1,4 @@
-(function() {
+w(function() {
     'use strict';
 
     var Utils = {
@@ -52,7 +52,9 @@
 
             if (attributes) {
                 for (var attribute in attributes) {
-                    editable.setAttribute(attribute, attributes[attribute]);
+                    if (Object.prototype.hasOwnProperty.call(attributes, attribute)) {
+                        editable.setAttribute(attribute, attributes[attribute]);
+                    }
                 }
             }
 


### PR DESCRIPTION
Hi Dustin,

Firstly I'd like to give you a detailed description about this issue: On master and 7.0.x Wiki portlet uses an AlloyEditor instance. In Creole mode we realized an issue which is already documented in LPS-68593. In fact the issue is when you add a link and set target attribute of that as a '_blank' value it doesn't work.

I checked Creole standard and based on that documentation I can say that Creole doesn't support target attribute on a link element. Furthermore I checked CKEditor behavior in Creole mode on ee-6.2.x and I found that we didn't have any opportunity to set target attribute on a link in that old version of portal.

In my opinion the issue is, int this case, that we display a target button in alloy editor despite Creole doesn't support it.

Thus I started to find a Config class on server side where I could set a config with "showTargetSelector = false"( I checked AlloyEditor api as well). I found "WikiLinksEditorConfigContributor.java" and I set the mention config on it. Rebuild and redeploy module but nothing happened. The target button is showed up.

I went to alloy-editor sorces and I checked "button-link-edit.jsx" and I noticed that we don't check "showTargetSelector" and we always display target button without checking the related property.

Finally, this pull contains my fix for this alloy-editor issue. Please check my modified demo and after checking you may delete it if you want. I couldn't make a new test case for it because I didn't find any places where I could set a config for an alloyEditor instantiation. Sorry about it.

After this pull would be merge to alloy-editor repo we need to build and release and modify version number of portal source. If it would be ready I could start to make a new config on server side to disappear the unnecesseary target button on AlloyEditor instance.

:):) That's all.

Please review it and let me know if you would be any question.
Thanks in advance,
 Zsaga